### PR TITLE
linker: Allow text-relocs for x86 (only)

### DIFF
--- a/linker/linker.cpp
+++ b/linker/linker.cpp
@@ -3013,12 +3013,14 @@ bool soinfo::link_image(const soinfo_list_t& global_group, const soinfo_list_t& 
   if (has_text_relocations) {
     // Fail if app is targeting sdk version > 22
     // TODO (dimitry): remove != __ANDROID_API__ check once http://b/20020312 is fixed
+#if !defined(__i386__) // ffmpeg says that they require text relocations on x86
     if (get_application_target_sdk_version() != __ANDROID_API__
         && get_application_target_sdk_version() > 22) {
       PRINT("%s: has text relocations", get_realpath());
       DL_ERR("%s: has text relocations", get_realpath());
       return false;
     }
+#endif
     // Make segments writable to allow text relocations to work properly. We will later call
     // phdr_table_protect_segments() after all of them are applied and all constructors are run.
     DL_WARN("%s has text relocations. This is wasting memory and prevents "


### PR DESCRIPTION
This effectively reverts

https://android.googlesource.com/platform/bionic/+/e4ad91f86a47b39612e030a162f4793cb3421d31%5E%21/#F0

for x86 platforms.  Unfortunately, this seems like it is required
if we are going to support ffmpeg.  The ffmpeg team decreed that they
require text relocations for x86 (only) and that they would not
fix the fact that android 6.0 makes ffmpeg unusable on x86:

https://trac.ffmpeg.org/ticket/4928

Change-Id: I68397f4d62f4f6acd8e0d41b7ecdc115969b890a
